### PR TITLE
Align license CSV style to the one used by trustify

### DIFF
--- a/src/cdx_license.rs
+++ b/src/cdx_license.rs
@@ -1,7 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
-use csv::Writer;
+use csv::{QuoteStyle, Writer, WriterBuilder};
 use std::error::Error;
 use regex::Regex;
 
@@ -52,15 +52,18 @@ pub struct LicenseHeader<'a>{
     namespace: &'a String,
     group: &'a String,
     version: &'a String,
+    #[serde(rename = "package reference")]
     package_reference: &'a String,
+    #[serde(rename = "license id")]
     license_id: &'a String,
+    #[serde(rename = "license name")]
     license_name: &'a String,
     //license_url: &'a String,
+    #[serde(rename = "license expression")]
     license_expression: &'a String,
+    #[serde(rename = "alternate package reference")]
     alternate_reference_locator: &'a String,
 }
-
-
 
 pub async fn get_cdx_bom_license(filepath: &str, output_path: &String){
     let mut file = File::open(filepath).await.expect("Error reading the file, make sure the path exists");
@@ -72,7 +75,12 @@ pub async fn get_cdx_bom_license(filepath: &str, output_path: &String){
 }
 
 pub async fn write_simple_cdx_csv(comp: &Components, csv_path: &String) -> Result<(), Box<dyn Error>>{
-    let mut wtr = Writer::from_path(csv_path)?;
+    let mut wtr = WriterBuilder::new()
+        .delimiter(b'\t')
+        .quote_style(QuoteStyle::Always)
+        .from_path(csv_path)?;
+
+    // let mut wtr = Writer::from_path(csv_path)?;
     let mut sbom_name = "";
     let mut sbom_group = "";
     let mut sbom_version = "";

--- a/src/spdx_license.rs
+++ b/src/spdx_license.rs
@@ -1,7 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
-use csv::Writer;
+use csv::{QuoteStyle, Writer, WriterBuilder};
 use std::error::Error; 
 use log::info;
 use regex::Regex;
@@ -46,17 +46,24 @@ pub struct LicenseHeader{
     namespace: String,
     group: String,
     version: String,
+    #[serde(rename = "package reference")]
     package_reference: String,
+    #[serde(rename = "license id")]
     license_id: String,
+    #[serde(rename = "license name")]
     license_name: String,
+    #[serde(rename = "license expression")]
     license_expression: String,
+    #[serde(rename = "alternate package reference")]
     alternate_ref: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LicenseRefHeader{
+    #[serde(rename = "licenseId")]
     license_id: String,
     name: String,
+    #[serde(rename = "extracted text")]
     extracted_text: String,
     comment: String,
 }
@@ -73,7 +80,11 @@ pub async fn get_spdx_bom_license(filepath: &str, output_path: &String, ref_file
 }
 
 pub async fn write_ref_csv(licenseRef: &HasLicenseInfo, ref_file_path: &String) -> Result<(), Box<dyn Error>>{
-    let mut wrt_ref = Writer::from_path(ref_file_path)?;
+    let mut wrt_ref = WriterBuilder::new()
+        .delimiter(b'\t')
+        .quote_style(QuoteStyle::Always)
+        .from_path(ref_file_path)?;
+
     if let Some(inner_license_map) = &licenseRef.hasExtractedLicensingInfos{
         if let Some(license_map) = inner_license_map{
             for license_info in license_map{
@@ -91,7 +102,11 @@ pub async fn write_ref_csv(licenseRef: &HasLicenseInfo, ref_file_path: &String) 
 }
 
 pub async fn write_simple_spdx_csv(packages: &Packages, license_extract: &HasLicenseInfo, csv_path: &String) -> Result<(), Box<dyn Error>>{
-    let mut wtr = Writer::from_path(csv_path)?;
+    let mut wtr = WriterBuilder::new()
+        .delimiter(b'\t')
+        .quote_style(QuoteStyle::Always)
+        .from_path(csv_path)?;
+
     for package in &packages.packages{
         let package_name = &package.name;
         let mut purl = "";


### PR DESCRIPTION
Using same CSV style as trustify project enables
direct diffing (diff/vimdiff etc) of downloaded files.

sbom json and license report csv files from trustification
```
$ ls -l
total 12
-rw-r--r--. 1 psedlak psedlak  164 Feb  5 03:15 fakeuclibc_license_ref.csv
-rw-r--r--. 1 psedlak psedlak  518 Feb  5 03:15 fakeuclibc_sbom_licenses.csv
-rw-r--r--. 1 psedlak psedlak 1939 Feb  5 14:06 spdx-fakeuclibc.json
```

use sbom-license-export (b60252d) to extract license info from sbom json
```
$ sbom-license-exporter -p spdx-fakeuclibc.json -t spdx
$ ls -l
total 20
-rw-r--r--. 1 psedlak psedlak  164 Feb  5 03:15 fakeuclibc_license_ref.csv
-rw-r--r--. 1 psedlak psedlak  518 Feb  5 03:15 fakeuclibc_sbom_licenses.csv
-rw-r--r--. 1 psedlak psedlak  452 Feb  5 14:07 license.csv
-rw-r--r--. 1 psedlak psedlak  141 Feb  5 14:07 license_ref.csv
-rw-r--r--. 1 psedlak psedlak    0 Feb  5 14:08 sbom_license.log
-rw-r--r--. 1 psedlak psedlak 1939 Feb  5 14:06 spdx-fakeuclibc.json
```

check if license ref is matching (result is false)
```
$ diff license_ref.csv fakeuclibc_license_ref.csv
1,3c1,3
< license_id,name,extracted_text,comment
< LicenseRef-A,FakeLicenseA,test A,my test license A
< LicenseRef-B,FakeLicenseB,test B,my test license B
---
> "licenseId"   "name"  "extracted text"        "comment"
> "LicenseRef-A"        "FakeLicenseA"  "test A"        "my test license A"
> "LicenseRef-B"        "FakeLicenseB"  "test B"        "my test license B"
```

check is sbom license list is matching (result is false)
```
$ diff license.csv fakeuclibc_sbom_licenses.csv
1,2c1,2
< name,namespace,group,version,package_reference,license_id,license_name,license_expression,alternate_ref
< fakeuclibc,https://anchore.com/syft/image/fake-uclibc-892c4b75-42cd-4f7c-a09d-d12900012345,,,,,,LicenseRef-A AND LicenseRef-B,"cpe:2.3:a:busybox:busybox:1.36.0:*:*:*:*:*:*:*
---
> "name"        "namespace"     "group" "version"       "package reference"     "license id"    "license name"  "license expression"    "alternate package reference"
> "fakeuclibc"  "https://anchore.com/syft/image/fake-uclibc-892c4b75-42cd-4f7c-a09d-d12900012345"       ""      ""      ""      ""      ""      "LicenseRef-A AND LicenseRef-B" "cpe:2.3:a:busybox:busybox:1.36.0:*:*:*:*:*:*:*
4c4
< fakeuclibc,https://anchore.com/syft/image/fake-uclibc-892c4b75-42cd-4f7c-a09d-d12900012345,,,,,,LicenseRef-A OR LicenseRef-B,
---
> "fakeuclibc"  "https://anchore.com/syft/image/fake-uclibc-892c4b75-42cd-4f7c-a09d-d12900012345"       ""      ""      ""      ""      ""      "LicenseRef-A OR LicenseRef-B"  ""
```

after this patch (tested with 8b4b9d8):
```
$ sbom-license-exporter -p spdx-fakeuclibc.json -t spdx
$ diff license_ref.csv fakeuclibc_license_ref.csv && echo match
match
$ diff license.csv fakeuclibc_sbom_licenses.csv  && echo match
match
```
